### PR TITLE
tfc-agent: always take latest 0.1.x version

### DIFF
--- a/charts/tfc-agent/Chart.yaml
+++ b/charts/tfc-agent/Chart.yaml
@@ -20,7 +20,7 @@ version: 0.6.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.1
+appVersion: "0.1"
 
 maintainers:
   - name: happycoil

--- a/charts/tfc-agent/Chart.yaml
+++ b/charts/tfc-agent/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.1.4
+appVersion: 0.1
 
 maintainers:
   - name: happycoil


### PR DESCRIPTION
The `0.1` tag is equivalent to `~> 0.1`.